### PR TITLE
use js to hit chatgpt api.  output in markdown.  input in readline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ You can also use the ChatGPT Wrapper on the command line:
 Run an interactive session in the terminal by using
 
 ```
-$ chatGPT
+$ chatgpt
 ```
 
 Or get the response for one question
 
 ``` bash
-$ chatGPT Write a grep command to find all names of functions in a python script
+$ chatgpt Write a grep command to find all names of functions in a python script
 ```
 <img width="600" alt="Screenshot 2022-12-03 at 21 11 44" src="https://user-images.githubusercontent.com/4510758/205460076-1defee06-7d62-4cfa-9f31-714d9cc669fc.png">
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a fork of [mmabrouk/chatgpt-wrapper](https://github.com/mmabrouk
 Here's whats different about it:
 
 * Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This should be more responsive and robust, and produce higher quality output.
+* Use `rich` library to render ChatGPT's markdown output in a terminal-friendly way.
 * Add a multi-line input system (blank line to end input)
 * Removed colors (they kept messing up my terminal)
 * Switched the browser to firefox.  In my experience, firefox can log in to Google oauth and Chromium can not.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Fork Notes
+
+This project is a fork of [mmabrouk/chatgpt-wrapper](https://github.com/mmabrouk/chatgpt-wrapper).
+
+Here's whats different about it:
+
+* Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This should be more responsive and robust, and produce higher quality output.
+* Add a multi-line input system (blank line to end input)
+* Removed colors
+* Switched the browser to firefox
+
+-------
+
+
 # ChatGPT Wrapper
 
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ Here's whats different about it:
 
 * Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This should be more responsive and robust, and produce higher quality output.
 * Add a multi-line input system (blank line to end input)
-* Removed colors
-* Switched the browser to firefox
+* Removed colors (they kept messing up my terminal)
+* Switched the browser to firefox.  In my experience, firefox can log in to Google oauth and Chromium can not.
+
+
+The contributions on this fork are licensed under the MIT license to match the parent project.
 
 -------
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Here's whats different about it:
 * Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This is more responsive and robust, and produces higher quality output.
 * Use `rich` library to render ChatGPT's markdown output in a terminal-friendly way.
 * Add a multi-line input system (blank line to end input)
-* Removed colors (they kept messing up my terminal)
-* Switched the browser to firefox.  In my experience, firefox can log in to Google oauth and Chromium can not.
+* Switched the browser to Firefox.  In my experience, Firefox can log in to Google oauth and Chromium can not.
 
 
 The contributions on this fork are licensed under the MIT license to match the parent project.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,3 @@
-# Fork Notes
-
-This project is a fork of [mmabrouk/chatgpt-wrapper](https://github.com/mmabrouk/chatgpt-wrapper).
-
-Here's whats different about it:
-
-* Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This is more responsive and robust, and produces higher quality output.
-* Use `rich` library to render ChatGPT's markdown output in a terminal-friendly way.
-* Add a multi-line input system (blank line to end input)
-* Switched the browser to Firefox.  In my experience, Firefox can log in to Google oauth and Chromium can not.
-
-
-The contributions on this fork are licensed under the MIT license to match the parent project.
-
--------
-
-
 # ChatGPT Wrapper
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a fork of [mmabrouk/chatgpt-wrapper](https://github.com/mmabrouk
 
 Here's whats different about it:
 
-* Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This should be more responsive and robust, and produce higher quality output.
+* Works by injecting JS in to the browser to interact with the chatgpt API directly, rather than interacting with the website.  This is more responsive and robust, and produces higher quality output.
 * Use `rich` library to render ChatGPT's markdown output in a terminal-friendly way.
 * Add a multi-line input system (blank line to end input)
 * Removed colors (they kept messing up my terminal)

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -1,3 +1,4 @@
+import base64
 import uuid
 import json
 import re
@@ -94,7 +95,7 @@ class ChatGPT:
               if(xhr.status == 200) {
                 var mydiv = document.createElement('DIV');
                 mydiv.id = "chatgpt-wrapper-conversation-data";
-                mydiv.innerHTML = xhr.responseText;
+                mydiv.innerHTML = btoa(xhr.responseText);
                 document.body.appendChild(mydiv);
               }
             };
@@ -117,7 +118,7 @@ class ChatGPT:
 
         self.parent_message_id = new_message_id
 
-        response = json.loads(conversation_datas[0].inner_html().split("\n\n")[-3][6:])
+        response = json.loads(base64.b64decode(conversation_datas[0].inner_html()).split(b"\n\n")[-3][6:])
         self.page.evaluate(
             "document.getElementById('chatgpt-wrapper-conversation-data').remove()"
         )

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -144,7 +144,7 @@ def main():
 
     if install_mode:
         print(
-            "Log in to ChatGPT in the browser that pops up.  Once that is acheived, you can ask questions here."
+            "Log in to ChatGPT in the browser that pops up, and click through all the dialogs, etc.  Once that is acheived, ctrl-c and restart this program without the 'install' parameter."
         )
 
     chatbot = ChatGPT(headless=not install_mode)

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -162,15 +162,7 @@ def main():
 
     while True:
 
-        lines = []
-        while True:
-            line = input("> ")
-            if line:
-                lines.append(line)
-            else:
-                break
-
-        inp = "\n".join(lines).strip()
+        inp = input("> ")
 
         if inp == "exit":
             sys.exit(0)

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -15,6 +15,7 @@ from rich.markdown import Markdown
 
 console = Console()
 
+
 class ChatGPT:
     """
     A ChatGPT interface that uses Playwright to run a browser,
@@ -84,8 +85,7 @@ class ChatGPT:
             "action": "next",
         }
 
-        code = (
-            """
+        code = """
             const xhr = new XMLHttpRequest();
             xhr.open('POST', 'https://chat.openai.com/backend-api/conversation');
             xhr.setRequestHeader('Accept', 'text/event-stream');
@@ -101,9 +101,10 @@ class ChatGPT:
             };
 
             xhr.send(JSON.stringify(REQUEST_JSON));
-            """
-            .replace("BEARER_TOKEN", self.session["accessToken"])
-            .replace("REQUEST_JSON", json.dumps(request))
+            """.replace(
+            "BEARER_TOKEN", self.session["accessToken"]
+        ).replace(
+            "REQUEST_JSON", json.dumps(request)
         )
 
         self.page.evaluate(code)
@@ -118,7 +119,9 @@ class ChatGPT:
 
         self.parent_message_id = new_message_id
 
-        response = json.loads(base64.b64decode(conversation_datas[0].inner_html()).split(b"\n\n")[-3][6:])
+        response = json.loads(
+            base64.b64decode(conversation_datas[0].inner_html()).split(b"\n\n")[-3][6:]
+        )
         self.page.evaluate(
             "document.getElementById('chatgpt-wrapper-conversation-data').remove()"
         )

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -31,25 +31,25 @@ class ChatGPT:
             headless=headless,
         )
         self.page = self.browser.new_page()
-        self.__start_browser()
+        self._start_browser()
 
 
-    def __start_browser(self):
+    def _start_browser(self):
         self.page.goto("https://chat.openai.com/")
-        if not self.__is_logged_in():
+        if not self._is_logged_in():
             print("Please log in to OpenAI Chat and accept the cookies box")
             print("Press enter when you're done")
             input()
 
-    def __get_input_box(self):
+    def _get_input_box(self):
         """Get the child textarea of `PromptTextarea__TextareaWrapper`"""
         return self.page.query_selector("textarea")
 
-    def __is_logged_in(self):
+    def _is_logged_in(self):
         # See if we have a textarea with data-id="root"
-        return self.__get_input_box() is not None
+        return self._get_input_box() is not None
 
-    def __parse_last_elem(self) -> str:
+    def _parse_last_elem(self) -> str:
         """Get the latest message"""
         try:
             msg = self.page.query_selector_all("div[class*='ConversationItem__Message']")[-1].inner_text()
@@ -58,22 +58,22 @@ class ChatGPT:
         msg = re.sub('\u200b', '', msg)
         return msg
 
-    def __send_message(self, message: str):
+    def _send_message(self, message: str):
         # Send the message
-        box = self.__get_input_box()
+        box = self._get_input_box()
         box.click()
         box.fill(message)
-        self.last_msg = self.__parse_last_elem()
+        self.last_msg = self._parse_last_elem()
         box.press("Enter")
 
-    def __get_last_message(self) -> str:
+    def _get_last_message(self) -> str:
         """Get the latest message"""
         page_elements = self.page.query_selector_all("div[class*='ConversationItem__Message']")
-        if self.__parse_last_elem() != self.last_msg:
+        if self._parse_last_elem() != self.last_msg:
             while True:
-                msg = self.__parse_last_elem()
+                msg = self._parse_last_elem()
                 sleep(1)
-                if msg == self.__parse_last_elem():
+                if msg == self._parse_last_elem():
                     break
             return msg
         return None
@@ -88,19 +88,17 @@ class ChatGPT:
         Returns:
             str: The response received from OpenAI.
         """
-        # logging.info("Sending message: %s", message)
-        self.__send_message(message)
+        self._send_message(message)
 
         timeout = time.time() + self.timeout
         while True:
-            response = self.__get_last_message()
+            response = self._get_last_message()
             if response:
                 break
             if time.time() > timeout:
                 raise TimeoutError("Timed out while waiting for the response")
 
-        response = self.__get_last_message()
-        # logging.info("Response: %s", response)
+        response = self._get_last_message()
         return response
 
 

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -119,6 +119,11 @@ class ChatGPT:
 
         self.parent_message_id = new_message_id
 
+        # the xhr response is an http event stream of json objects.
+        # the div contains that entire response, base64 encoded to
+        # avoid html entities issues.  the complete response is always
+        # the third from last event.  the json itself always begins at
+        # character 6.
         response = json.loads(
             base64.b64decode(conversation_datas[0].inner_html()).split(b"\n\n")[-3][6:]
         )

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import re
+import readline
 import sys
 import tempfile
 import time

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -1,6 +1,5 @@
 import uuid
 import json
-import logging
 import re
 import os
 import sys
@@ -10,20 +9,19 @@ from time import sleep
 import tempfile
 from playwright.sync_api import sync_playwright
 
-logging.basicConfig(level=logging.INFO)
+from rich.console import Console
+from rich.markdown import Markdown
 
+console = Console()
 
 class ChatGPT:
     """
-    An ChatGPT chatbot that uses Playwright to simulate a Chrome browser.
-    The chatbot can be used to send messages to OpenAI and receive responses.
-    First time used, the user must log in to OpenAI Chat and accept the cookies box.
-    Developed with the help of chatgpt :)
+    A ChatGPT interface that uses Playwright to run a browser,
+    and interacts with that browser to communicate with ChatGPT in
+    order to provide a command line interface to ChatGPT.
     """
 
-    def __init__(self, headless: bool = True, timeout: int = 600):
-        self.timeout = timeout
-        self.last_msg = None
+    def __init__(self, headless: bool = True):
         self.play = sync_playwright().start()
         self.browser = self.play.firefox.launch_persistent_context(
             user_data_dir=f"/tmp/playwright",
@@ -100,6 +98,7 @@ class ChatGPT:
                 document.body.appendChild(mydiv);
               }
             };
+
             xhr.send(JSON.stringify(REQUEST_JSON));
             """
             .replace("BEARER_TOKEN", self.session["accessToken"])
@@ -148,7 +147,8 @@ def main():
             "Log in to ChatGPT in the browser that pops up, and click through all the dialogs, etc.  Once that is acheived, ctrl-c and restart this program without the 'install' parameter."
         )
 
-    chatbot = ChatGPT(headless=not install_mode)
+    chatgpt = ChatGPT(headless=not install_mode)
+
     while True:
 
         lines = []
@@ -163,8 +163,10 @@ def main():
 
         if inp == "exit":
             sys.exit(0)
-        response = chatbot.ask(inp)
-        print("\n" + response + "\n")
+        response = chatgpt.ask(inp)
+        print("\n")
+        console.print(Markdown(response))
+        print("\n")
 
 
 if __name__ == "__main__":

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -114,11 +114,21 @@ def main():
             sys.exit()
     chatbot = ChatGPT()
     while True:
-        inp = input("You: ")
+
+        lines = []
+        while True:
+            line = input('> ')
+            if line:
+                lines.append(line)
+            else:
+                break
+        
+        inp = "\n".join(lines).strip()
+        
         if inp == "exit":
             sys.exit(0)
         response = chatbot.ask(inp)
-        print("\nChatGPT: " + response + "\n")
+        print("\n" + response + "\n")
 
 
 if __name__ == "__main__":

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -7,7 +7,6 @@ import time
 import tempfile
 from time import sleep
 import tempfile
-from colorama import Fore, init
 from playwright.sync_api import sync_playwright
 
 logging.basicConfig(level=logging.INFO)
@@ -22,27 +21,25 @@ class ChatGPT:
     """
 
     def __init__(self, headless: bool = True, timeout: int = 60):
-        print(Fore.MAGENTA + "Starting ...", end=" ")
         if not headless:
-            print(Fore.WHITE + "\n Please login to OpenAI Chat and accept the cookies box then restart the script")
+            print("\n Please login to OpenAI Chat and accept the cookies box then restart the script")
         self.timeout = timeout
         self.last_msg = None
         self.play = sync_playwright().start()
-        self.browser = self.play.chromium.launch_persistent_context(
+        self.browser = self.play.firefox.launch_persistent_context(
             user_data_dir=f"/tmp/playwright",
             headless=headless,
         )
         self.page = self.browser.new_page()
         self.__start_browser()
 
+
     def __start_browser(self):
         self.page.goto("https://chat.openai.com/")
         if not self.__is_logged_in():
-            init()  # Enable ANSI escape sequences
-            print(Fore.YELLOW + "Please log in to OpenAI Chat and accept the cookies box")
-            print(Fore.YELLOW + "Press enter when you're done")
+            print("Please log in to OpenAI Chat and accept the cookies box")
+            print("Press enter when you're done")
             input()
-        print(Fore.WHITE + "Done")
 
     def __get_input_box(self):
         """Get the child textarea of `PromptTextarea__TextareaWrapper`"""
@@ -115,16 +112,15 @@ def main():
         else:
             chatbot = ChatGPT()
             # Print the output of chatbot.ask and exit the script
-            print(Fore.MAGENTA + "Asking...", end="\n")
-            print(Fore.GREEN + chatbot.ask(" ".join(sys.argv[1:])))
+            print(chatbot.ask(" ".join(sys.argv[1:])))
             sys.exit()
     chatbot = ChatGPT()
     while True:
-        inp = input(Fore.YELLOW + "You: ")
+        inp = input("You: ")
         if inp == "exit":
             sys.exit(0)
         response = chatbot.ask(inp)
-        print(Fore.GREEN + "\nChatGPT: " + response + "\n")
+        print("\nChatGPT: " + response + "\n")
 
 
 if __name__ == "__main__":

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -1,15 +1,14 @@
 import base64
-import uuid
 import json
-import re
 import os
+import re
 import sys
+import tempfile
 import time
-import tempfile
+import uuid
 from time import sleep
-import tempfile
-from playwright.sync_api import sync_playwright
 
+from playwright.sync_api import sync_playwright
 from rich.console import Console
 from rich.markdown import Markdown
 
@@ -141,14 +140,24 @@ class ChatGPT:
 
 
 def main():
-    install_mode = len(sys.argv) > 1 and (sys.argv[1] == "install")
 
+    install_mode = len(sys.argv) > 1 and (sys.argv[1] == "install")
     if install_mode:
         print(
             "Log in to ChatGPT in the browser that pops up, and click through all the dialogs, etc.  Once that is acheived, ctrl-c and restart this program without the 'install' parameter."
         )
 
     chatgpt = ChatGPT(headless=not install_mode)
+
+    def ask_and_answer(prompt):
+        response = chatgpt.ask(prompt)
+        print("")
+        console.print(Markdown(response))
+        print("")
+
+    if len(sys.argv) > 1 and not install_mode:
+        ask_and_answer(" ".join(sys.argv[1:]))
+        return
 
     while True:
 
@@ -164,10 +173,8 @@ def main():
 
         if inp == "exit":
             sys.exit(0)
-        response = chatgpt.ask(inp)
-        print("\n")
-        console.print(Markdown(response))
-        print("\n")
+
+        ask_and_answer(inp)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 playwright
+rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 playwright
+readline
 rich


### PR DESCRIPTION
In my fork, I have altered the way your wrapper works quite a bit.  Here are a list of changes you will find here:

* It now works by evaluating our own JS in to the browser to interact with the ChatGPT API directly, rather than interacting with the website textarea/button and conversation dom elements.  This is more responsive and produces higher quality output.  We now get pure markdown output from ChatGPT.
* Improve output: Use `rich` library to render ChatGPT's markdown output in a fancy and terminal friendly way.. adds word wrapping to fit your terminal.  
* Improve input: Use `readline` library to improve interactive mode editing..  you can use the arrow keys now. it even has history.
* Conversation clear feature.  Uses `cmd` library to implement custom commands in the interpreter. now you can say "clear" to clear your conversational context. "exit" is also supported
* Switched the browser to Firefox.  In my experience, Firefox can log in to Google oauth and Chromium can not (when its being remote-controlled)

The contributions on this fork are licensed under the MIT license to match the parent project.
