### PR TITLE
add pyreadline for windows support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask
 playwright
-readline
+pyreadline
 rich


### PR DESCRIPTION
I think by putting `pyreadline` in our `requirements.txt` it will make things work for windows users..?  I don't have a windows machine to try this on