### PR TITLE
provide nav command to revisit previous contexts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     
 setup(
     name="chatGPT",
-    version="0.1.2",
+    version="0.2.0",
     author="Mahmoud Mabrouk",
     author_email="mahmoudmabrouk.mail@gmail.com",
     description="A simple Python class for interacting with OpenAI's chatGPT using Playwright",


### PR DESCRIPTION
Add ability to navigate to past contexts using prompt numbers with `nav` command.  Rename `clear` to `new` since it's not really clearing anything, you can always navigate back.

Also uprev.