### PR TITLE
Set title for new chat

### DIFF
--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -6,6 +6,7 @@ import time
 import uuid
 import os
 import shutil
+import urllib
 from functools import reduce
 from time import sleep
 from typing import Optional
@@ -59,6 +60,7 @@ class ChatGPT:
         self._start_browser()
         self.parent_message_id = str(uuid.uuid4())
         self.conversation_id = None
+        self.conversation_title_set = None
         self.session = None
         self.model = model
         self.timeout = timeout
@@ -107,6 +109,34 @@ class ChatGPT:
     def _cleanup_divs(self):
         self.page.evaluate(f"document.getElementById('{self.stream_div_id}').remove()")
         self.page.evaluate(f"document.getElementById('{self.eof_div_id}').remove()")
+
+    def _api_request_build_headers(self, custom_headers={}):
+        headers = {
+            "Authorization": "Bearer %s" % self.session["accessToken"],
+        }
+        headers.update(custom_headers)
+        return headers
+
+    def _api_post_request(self, url, data={}, custom_headers={}):
+        headers = self._api_request_build_headers(custom_headers)
+        response = self.page.request.post(url, headers=headers, data=data)
+        return response
+
+    def _set_title(self):
+        if not self.conversation_id or self.conversation_id and self.conversation_title_set:
+            return
+        url = f"https://chat.openai.com/backend-api/conversation/gen_title/{self.conversation_id}"
+        data = {
+            "message_id": self.parent_message_id,
+            "model": RENDER_MODELS[self.model],
+        }
+        response = self._api_post_request(url, data)
+        if response.ok:
+            # TODO: Do we want to do anything with the title we got back?
+            # response_data = response.json()
+            self.conversation_title_set = True
+        else:
+            raise urllib.error.HttpError("Set title request failed with status code: %s, status message: %s\n" % (response.status, response.status_text))
 
     def ask_stream(self, prompt: str):
         if self.session is None:
@@ -235,6 +265,7 @@ class ChatGPT:
             sleep(0.2)
 
         self._cleanup_divs()
+        self._set_title()
 
     def ask(self, message: str) -> str:
         """
@@ -256,3 +287,4 @@ class ChatGPT:
     def new_conversation(self):
         self.parent_message_id = str(uuid.uuid4())
         self.conversation_id = None
+        self.conversation_title_set = None

--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -12,6 +12,11 @@ from typing import Optional
 from playwright.sync_api import sync_playwright
 from playwright._impl._api_structures import ProxySettings
 
+RENDER_MODELS = {
+    "default": "text-davinci-002-render-sha",
+    "legacy": "text-davinci-002-render-paid",
+}
+
 
 class ChatGPT:
     """
@@ -24,7 +29,7 @@ class ChatGPT:
     eof_div_id = "chatgpt-wrapper-conversation-stream-data-eof"
     session_div_id = "chatgpt-wrapper-session-data"
 
-    def __init__(self, headless: bool = True, browser="firefox", timeout=60, proxy: Optional[ProxySettings] = None):
+    def __init__(self, headless: bool = True, browser="firefox", model="default", timeout=60, proxy: Optional[ProxySettings] = None):
         self.play = sync_playwright().start()
 
         try:
@@ -55,6 +60,7 @@ class ChatGPT:
         self.parent_message_id = str(uuid.uuid4())
         self.conversation_id = None
         self.session = None
+        self.model = model
         self.timeout = timeout
         atexit.register(self._cleanup)
 
@@ -124,7 +130,7 @@ class ChatGPT:
                     "content": {"content_type": "text", "parts": [prompt]},
                 }
             ],
-            "model": "text-davinci-002-render-sha",
+            "model": RENDER_MODELS[self.model],
             "conversation_id": self.conversation_id,
             "parent_message_id": self.parent_message_id,
             "action": "next",

--- a/chatgpt_wrapper/main.py
+++ b/chatgpt_wrapper/main.py
@@ -37,6 +37,13 @@ def main():
         action="store",
         help="set preferred browser; 'firefox' 'chromium' or 'webkit'",
     )
+    parser.add_argument(
+        "-m",
+        "--model",
+        choices=['default', 'legacy'],
+        action="store",
+        help="set preferred model",
+    )
     args = parser.parse_args()
     install_mode = len(args.params) == 1 and args.params[0] == "install"
 
@@ -47,7 +54,11 @@ def main():
             "this program without the 'install' parameter.\n"
         )
 
-    extra_kwargs = {} if args.browser is None else {"browser": args.browser}
+    extra_kwargs = {}
+    if args.browser is not None:
+        extra_kwargs["browser"] = args.browser
+    if args.model is not None:
+        extra_kwargs["model"] = args.model
     chatgpt = ChatGPT(headless=not install_mode, timeout=90, **extra_kwargs)
 
     shell = GPTShell()


### PR DESCRIPTION
Uses the `/backend-api/conversation/gen_title/[id] POST endpoint`

Note this PR requires PR #109 to function properly.

One optimization that could be made before committing: the POST request is a sync request after the very first message is sent in a new conversation, and the time it takes delays the display of prompt `2>` until the request completes. Once the title is set there is no delay for other messages in the conversation.

Also note that I abstracted an `_api_post_request()` method, and with a little more work, it would be trivial to add other helpful API requests, such as #106.