### PR TITLE
Don't submit empty lines

### DIFF
--- a/chatgpt_wrapper/gpt_shell.py
+++ b/chatgpt_wrapper/gpt_shell.py
@@ -131,6 +131,8 @@ class GPTShell(cmd.Cmd):
         return self.default(line)
 
     def default(self, line):
+        if not line:
+            return
 
         if self.stream:
             response = ""


### PR DESCRIPTION
Currently, the CLI submits empty lines to the API, which creates delays and unnecessary responses. This patch skips submitting empty lines to the API