### PR TITLE
!write command, builds command in an editor

### DIFF
--- a/chatgpt_wrapper/gpt_shell.py
+++ b/chatgpt_wrapper/gpt_shell.py
@@ -2,6 +2,7 @@ import cmd
 import os
 import platform
 import sys
+import subprocess
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -186,6 +187,20 @@ class GPTShell(cmd.Cmd):
             readline.add_history(prompt)
 
         self.default(prompt)
+
+    def do_write(self, args):
+        "`!write` Open an editor for entering a command (requires `vipe` executable). `!write some default text`"
+        try:
+            process = subprocess.Popen(['vipe'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        except FileNotFoundError:
+            self._print_markdown("Failed to execute `vipe`, must be installed and in path")
+            return
+        process.stdin.write(args.encode())
+        process.stdin.close()
+        process.wait()
+        output = process.stdout.read().decode()
+        print(output)
+        self.default(output)
 
     def do_file(self, arg):
         "`!file` sends a prompt read from the named file.  Example: `file myprompt.txt`"


### PR DESCRIPTION
Leverages the easily installable `vipe` executable:
 - opens default terminal editor
 - passes any arguments to !write as the initial text in the editor
 - collects final text from the editor when closed
 - outputs text to screen for viewing
 - sends text as the entered command.

May be possible to use other pipe editors, did not investigate since vipe is so widely available.

On a personal note, this feature is a game changer for me. To be able to 'prepare' my command using my native editor, leverage keyboard shortcuts, see syntax highlighting, edit mistakes, etc., makes this CLI tool far more useful and fun!