### PR TITLE
!delete support for history IDs/UUIDs

### DIFF
--- a/chatgpt_wrapper/gpt_shell.py
+++ b/chatgpt_wrapper/gpt_shell.py
@@ -95,10 +95,19 @@ class GPTShell(cmd.Cmd):
         return list(set(final_list))
 
     def _delete_conversation(self, id, label=None):
-        label = label or id
-        self._print_markdown("* Deleting conversation: %s" % label)
-        self.chatgpt.delete_conversation(id)
-        self._print_markdown("* Deleted conversation: %s" % label)
+        if id == self.chatgpt.conversation_id:
+            self._delete_current_conversation()
+        else:
+            label = label or id
+            self._print_markdown("* Deleting conversation: %s" % label)
+            self.chatgpt.delete_conversation(id)
+            self._print_markdown("* Deleted conversation: %s" % label)
+
+    def _delete_current_conversation(self):
+        self._print_markdown("* Deleting current conversation")
+        self.chatgpt.delete_conversation()
+        self._print_markdown("* Deleted current conversation")
+        self.do_new(None)
 
     def emptyline(self):
         """
@@ -141,10 +150,7 @@ class GPTShell(cmd.Cmd):
             else:
                 self._print_markdown(result)
         else:
-            self._print_markdown("* Deleting current conversation")
-            self.chatgpt.delete_conversation()
-            self._print_markdown("* Deleted current conversation")
-            self.do_new(None)
+            self._delete_current_conversation()
 
     def do_history(self, _):
         "`!history` show recent conversation history, last 20 conversations."


### PR DESCRIPTION
`!delete` command can now take a list of history IDs/UUIDs to delete any conversations that exist in history.

 - multiple IDs can be separated by commas, e.g. `1,2`
 - ranges of history IDs can be separated by a dash, e.g `3-5`
 - conversation UUIDs supported

Example of a complete command: `!delete 1,3-5,963cb5e1-37f0-4f44-9fa2-d7aef8ca2d9c`

Also forced a session refresh for `!delete` if needed, and cleaned up an error in the exception handling.