### PR TITLE
Avoid `docker-entrypoint.sh` treating text as commands

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo "----- Please following these steps -----"
-echo "1) Run command `docker exec -it chatgpt-wrapper-container /bin/bash -c \"chatgpt install\"`"
-echo "2) Visit http://localhost:6901/vnc.html with password `headless`"
-echo "3) Login ChatGPT"
-echo "4) Back to terminal here and have a nice chat"
+echo '1) Run command `docker exec -it chatgpt-wrapper-container /bin/bash -c \"chatgpt install\"`'
+echo '2) Visit http://localhost:6901/vnc.html with password `headless`'
+echo '3) Login ChatGPT'
+echo '4) Back to terminal here and have a nice chat'
 
 python # just holding


### PR DESCRIPTION
Using single quotes instead of double quotes to avoid bash executing `docker` and `headless` as commands.