### PR TITLE
Removed warning failed to set title

### DIFF
--- a/chatgpt_wrapper/chatgpt.py
+++ b/chatgpt_wrapper/chatgpt.py
@@ -175,7 +175,8 @@ class ChatGPT:
             # response_data = response.json()
             self.conversation_title_set = True
         else:
-            self.log.warning("Failed to set title")
+            # self.log.warning("Failed to set title")
+            pass
 
     def delete_conversation(self, uuid=None):
         if self.session is None:


### PR DESCRIPTION
Setting a title is not working most of the time. As a result we are getting a warning most of the time, I removed it until we find a solution to the problem