### PR TITLE
Stop generating streaming response on keyboard interrupt

### DIFF
--- a/chatgpt_wrapper/gpt_shell.py
+++ b/chatgpt_wrapper/gpt_shell.py
@@ -44,7 +44,7 @@ class GPTShell():
 
     intro = "Provide a prompt for ChatGPT, or type %shelp or ? to list commands." % COMMAND_LEADER
     prompt = "> "
-    doc_header = "Documented commands (type %shelp [command without leading %s]):" % (COMMAND_LEADER, COMMAND_LEADER)
+    doc_header = "Documented commands type %shelp [command without %s] (e.g. /help ask) for detailed help" % (COMMAND_LEADER, COMMAND_LEADER)
 
     # our stuff
     prompt_number = 0


### PR DESCRIPTION
Mostly kinda working. Two remaining issues:

1. I haven't been able to figure out how to hook it to a key press from either the native `signal` module, nor `prompt_toolkit`'s keybindings, nor via `asyncio`'s signal handling -- they all give different errors. But, I  *can* send a signal from the system and that's working perfectly. At this moment, a SIGUSR1 will stop generating in the middle of a stream and properly clean up the running stream in the browser. Here's the script I'm using to send the SIGUSR1, which should be trivial to hook to a keypress at the OS level:
    ````bash
    #!/bin/bash

    PROGNAME="chatgpt"

    pid=$(pidof -x ${PROGNAME})
    if [ -n "${pid}" ]; then
      kill -SIGUSR1 ${pid}
    fi
    ````
2. `gen_title` fails when a streaming response is interrupted, not sure why, as we have the proper conversation ID, but the POST fails with a 404. maybe we need a short delay before sending the post.