### PR TITLE
removed self.console call from repl.py

### DIFF
--- a/chatgpt_wrapper/backends/openai/repl.py
+++ b/chatgpt_wrapper/backends/openai/repl.py
@@ -165,7 +165,6 @@ class ApiRepl(Repl):
     async def check_login(self):
         user_count = self.session.query(User).count()
         if user_count == 0:
-            self.console.print("No users in database. Creating one...", style="bold red")
             self.welcome_message()
             await self.create_first_user()
         # Special case check: if there's only one user in the database, and

--- a/chatgpt_wrapper/backends/openai/repl.py
+++ b/chatgpt_wrapper/backends/openai/repl.py
@@ -165,6 +165,7 @@ class ApiRepl(Repl):
     async def check_login(self):
         user_count = self.session.query(User).count()
         if user_count == 0:
+            util.print_status_message(True, "No users in database. Creating one...")
             self.welcome_message()
             await self.create_first_user()
         # Special case check: if there's only one user in the database, and


### PR DESCRIPTION
Removed line that called `self.console.print`, as it was causing an error during user creation in the database. The `ApiRepl` object  does not have a `console` attribute.

  File "/opt/homebrew/lib/python3.11/site-packages/chatgpt_wrapper/backends/openai/repl.py", line 168, in check_login
    self.console.print("No users in database. Creating one...", style="bold red")
    ^^^^^^^^^^^^
AttributeError: 'ApiRepl' object has no attribute 'console'