### PR TITLE
prepend /src to PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM accetto/ubuntu-vnc-xfce-python-g3:vscode-firefox
 
+ENV PYTHONPATH=/src:$PYTHONPATH
+
 USER root
 
 # Pkgs for default database


### PR DESCRIPTION
It should fix the ModuleNotFoundError: No module named 'chatgpt_wrapper'. Previously, the path `/src` was not included in the `PYTHONPATH` varaible which will be used to search for packages etc.